### PR TITLE
cross: add LibreSSL as optional SSL backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,11 +55,25 @@ set(GGML_NATIVE OFF CACHE BOOL "" FORCE)
 set(GGML_OPENMP OFF CACHE BOOL "" FORCE)
 set(GGML_LTO    OFF CACHE BOOL "" FORCE)
 
-set(LLAMA_BUILD_BORINGSSL ON  CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_BORINGSSL OFF CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_LIBRESSL  ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_COMMON    ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_TOOLS     ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_SERVER    ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_APP       ON  CACHE BOOL "" FORCE)
+
+# Zig clang in cross mode to x86_64-windows-gnu exposes glibc symbols (syslog,
+# getentropy, ...) that LibreSSL's check_function_exists picks up as available
+# but that fail to compile because the mingw headers do not declare them.
+# Pin these probes to FALSE so the compat layer keeps its Windows fallbacks.
+set(HAVE_GETENTROPY FALSE CACHE INTERNAL "")
+set(HAVE_SYSLOG     FALSE CACHE INTERNAL "")
+set(HAVE_SYSLOG_R   FALSE CACHE INTERNAL "")
+
+# LibreSSL ships mingw64 perlasm output that uses COFF directives like .def /
+# .scl / .endef which the Zig clang assembler does not understand. Disable the
+# assembly path so the C fallback is used in this cross compile.
+set(ENABLE_ASM OFF CACHE BOOL "" FORCE)
 
 #add_compile_options(
 #    -ffp-model=fast
@@ -97,6 +111,11 @@ else()
         TARGET_DIRECTORY ggml-cpu
         APPEND PROPERTY COMPILE_OPTIONS "-fno-unroll-loops"
     )
+    # LTO through clang cross to mingw miscompiles the SSL stack bignum, which
+    # silently hangs the TLS handshake on the Windows prebuilds. Keep LTO off
+    # on the crypto and ssl targets even when the global IPO is on.
+    set_target_properties(crypto PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
+    set_target_properties(ssl    PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
 endif()
 
 llama_install_link_win32_shim(${LLAMA_INSTALL_TARGET})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,25 +55,29 @@ set(GGML_NATIVE OFF CACHE BOOL "" FORCE)
 set(GGML_OPENMP OFF CACHE BOOL "" FORCE)
 set(GGML_LTO    OFF CACHE BOOL "" FORCE)
 
-set(LLAMA_BUILD_BORINGSSL OFF CACHE BOOL "" FORCE)
-set(LLAMA_BUILD_LIBRESSL  ON  CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_BORINGSSL ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_COMMON    ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_TOOLS     ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_SERVER    ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_APP       ON  CACHE BOOL "" FORCE)
 
-# Zig clang in cross mode to x86_64-windows-gnu exposes glibc symbols (syslog,
-# getentropy, ...) that LibreSSL's check_function_exists picks up as available
-# but that fail to compile because the mingw headers do not declare them.
-# Pin these probes to FALSE so the compat layer keeps its Windows fallbacks.
-set(HAVE_GETENTROPY FALSE CACHE INTERNAL "")
-set(HAVE_SYSLOG     FALSE CACHE INTERNAL "")
-set(HAVE_SYSLOG_R   FALSE CACHE INTERNAL "")
+# LibreSSL is supported as an alternative SSL backend in this cross Zig
+# pipeline. It needs a few knobs to build cleanly when selected with
+# -DLLAMA_BUILD_LIBRESSL=ON -DLLAMA_BUILD_BORINGSSL=OFF.
+if(LLAMA_BUILD_LIBRESSL)
+    # Zig clang in cross mode to x86_64-windows-gnu exposes glibc symbols
+    # (syslog, getentropy, ...) that LibreSSL's check_function_exists picks up
+    # as available but that fail to compile because the mingw headers do not
+    # declare them. Pin these probes to FALSE so the compat layer keeps its
+    # Windows fallbacks.
+    set(HAVE_GETENTROPY FALSE CACHE INTERNAL "")
+    set(HAVE_SYSLOG     FALSE CACHE INTERNAL "")
 
-# LibreSSL ships mingw64 perlasm output that uses COFF directives like .def /
-# .scl / .endef which the Zig clang assembler does not understand. Disable the
-# assembly path so the C fallback is used in this cross compile.
-set(ENABLE_ASM OFF CACHE BOOL "" FORCE)
+    # LibreSSL ships mingw64 perlasm output that uses COFF directives like
+    # .def / .scl / .endef which the Zig clang assembler does not understand.
+    # Disable the assembly path so the C fallback is used in this cross compile.
+    set(ENABLE_ASM OFF CACHE BOOL "" FORCE)
+endif()
 
 #add_compile_options(
 #    -ffp-model=fast
@@ -111,11 +115,6 @@ else()
         TARGET_DIRECTORY ggml-cpu
         APPEND PROPERTY COMPILE_OPTIONS "-fno-unroll-loops"
     )
-    # LTO through clang cross to mingw miscompiles the SSL stack bignum, which
-    # silently hangs the TLS handshake on the Windows prebuilds. Keep LTO off
-    # on the crypto and ssl targets even when the global IPO is on.
-    set_target_properties(crypto PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
-    set_target_properties(ssl    PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
 endif()
 
 llama_install_link_win32_shim(${LLAMA_INSTALL_TARGET})


### PR DESCRIPTION
Adds LibreSSL as an optional SSL backend for the Windows cross build (Zig clang to x86_64-windows-gnu). BoringSSL stays the default; LibreSSL is selected with -DLLAMA_BUILD_LIBRESSL=ON -DLLAMA_BUILD_BORINGSSL=OFF.

Two knobs are needed to build LibreSSL cleanly through Zig clang, both verified mandatory by build:

- HAVE_GETENTROPY and HAVE_SYSLOG pinned to FALSE: Zig clang exposes glibc symbols that LibreSSL's check_function_exists picks up, but the mingw headers do not declare them, so the compat layer fails on vsyslog.

- ENABLE_ASM=OFF: LibreSSL's mingw64 perlasm uses COFF directives (.def / .scl / .endef) that the Zig clang assembler does not parse.

Context: this PR originally switched the default to LibreSSL to work around the BoringSSL handshake freeze. That freeze is now fixed at the root by the winpthreads spinlock convention patch (e81f0f3), so BoringSSL stays the default and LibreSSL is just kept available as an alternative.

Tested under wine: both backends complete the HTTPS handshake to Hugging Face and start the model download.