### PR TITLE
Allow updating on Windows while llama is running

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -70,6 +70,9 @@ function Main {
             "Please compile llama.cpp from source instead."
     }
 
+    if (Test-Path "$INSTALL_DIR\llama.exe") {
+        Move-Item "$INSTALL_DIR\llama.exe" "$DIR\llama.exe.old" -Force
+    }
     Move-Item "$DIR\llama.exe" "$INSTALL_DIR\llama.exe" -Force
     Remove-Item $DIR -Recurse -Force 2>$null
 


### PR DESCRIPTION
The `.old` will be deleted at the next update