### PR TITLE
install: rename the locked exe within INSTALL_DIR so windows update can swap

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -71,7 +71,7 @@ function Main {
     }
 
     if (Test-Path "$INSTALL_DIR\llama.exe") {
-        Move-Item "$INSTALL_DIR\llama.exe" "$DIR\llama.exe.old" -Force
+        Move-Item "$INSTALL_DIR\llama.exe" "$INSTALL_DIR\llama.exe.old" -Force
     }
     Move-Item "$DIR\llama.exe" "$INSTALL_DIR\llama.exe" -Force
     Remove-Item $DIR -Recurse -Force 2>$null


### PR DESCRIPTION
I would need this small fix to test update on Windows