### PR TITLE
Fix slient CPU fallback when zstd is missing

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -52,10 +52,36 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: ${{ matrix.llama }} bench -v -hf ggml-org/test-model-stories260K
 
+  test-no-zstd:
+    name: Test (linux, no zstd)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Hide zstd
+        run: |
+          ZSTD=$(command -v zstd) && sudo mv "$ZSTD" /tmp/zstd.disabled
+          ! command -v zstd
+
+      - name: Install
+        env:
+          LLAMA_BUCKET: ${{ vars.HF_REPO }}
+          LLAMA_VERSION: ${{ inputs.llamacpp_version }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: sh install.sh
+
+      - name: Check downloaded binaries
+        run: |
+          for FILE in ~/.llama-app/*; do
+            head -c 4 "$FILE" | od -An -tx1 | tr -d ' \n' | grep -qx 7f454c46 ||
+              { printf "%s: not an ELF binary\n" "$FILE" >&2; exit 1; }
+          done
+
   latest:
     runs-on: ubuntu-latest
     needs:
       - test
+      - test-no-zstd
     if: ${{ vars.HF_REPO != '' && inputs.write_latest == true && inputs.llamacpp_version != '' }}
     steps:
       - uses: actions/checkout@v5

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,9 @@ curl() {
 dl_bin() {
 	[ -x "$1" ] && return
 	check_bin curl || die "Please install curl"
+	case "$2" in
+	(*.zst) check_bin zstd || dl_bin unzstd "$ARCH/$OS/unzstd" || return 1 ;;
+	esac
 	printf "Downloading %s...\n" "$1"
 	case "$2" in
 	(*.zst) curl -fsSL "$REPO/$LLAMA_VERSION/$2" | unzstd ;;
@@ -38,8 +41,7 @@ dl_bin() {
 }
 
 unzstd() (
-	command -v zstd >/dev/null 2>/dev/null && exec zstd -d
-	dl_bin unzstd "$ARCH/$OS/unzstd"
+	check_bin zstd && exec zstd -d
 	exec ./unzstd
 )
 


### PR DESCRIPTION
**Problem**
The `zstd` CLI is missing from most base images. Without `zstd`, the first `.zst` artefact is corrupted. On Linux that is `cuda-probe`, so CUDA detection fails and a CPU-only build is installed silently on an NVIDIA machine.

**Fix**
Resolve the decompressor before entering the redirected pipeline.

**Test**
Mock bucket simulating `x86_64` Linux with CUDA: without `zstd`, the installer picked a CPU build before the fix and the CUDA build after. New `test-no-zstd` job hides `zstd` and asserts downloaded artefacts are valid ELFs.