### PR TITLE
Fix version check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,7 @@ main() {
 		"Downloaded llama binary failed to run"
 
 	echo "$VERSION" | grep -q "build ${LLAMA_VERSION#b}" || die \
-		"Version mismatch: expected build ${LLAMA_VERSION#b}, got $VERSION
+		"Version mismatch: expected build ${LLAMA_VERSION#b}, got $VERSION"
 
 	mkdir -p ~/.local/bin &&
 	cp ~/.llama-app/llama ~/.local/bin/llama.tmp &&

--- a/install.sh
+++ b/install.sh
@@ -153,8 +153,11 @@ main() {
 	VERSION=$(~/.llama-app/llama version 2>/dev/null) || die \
 		"Downloaded llama binary failed to run"
 
-	echo "$VERSION" | grep -q "build ${LLAMA_VERSION#b}" || die \
-		"Version mismatch: expected build ${LLAMA_VERSION#b}, got $VERSION"
+    case "$VERSION" in
+    ("$LLAMA_VERSION"-*) ;;
+    (*"build ${LLAMA_VERSION#b}"*) ;;
+	(*) die "Version mismatch: expected build ${LLAMA_VERSION#b}, got $VERSION" ;;
+	esac
 
 	mkdir -p ~/.local/bin &&
 	cp ~/.llama-app/llama ~/.local/bin/llama.tmp &&

--- a/install.sh
+++ b/install.sh
@@ -153,10 +153,8 @@ main() {
 	VERSION=$(~/.llama-app/llama version 2>/dev/null) || die \
 		"Downloaded llama binary failed to run"
 
-	case "$VERSION" in
-	("$LLAMA_VERSION"-*) ;;
-	(*) die "Version mismatch: expected $LLAMA_VERSION, got $VERSION" ;;
-	esac
+	echo "$VERSION" | grep -q "build ${LLAMA_VERSION#b}" || die \
+		"Version mismatch: expected build ${LLAMA_VERSION#b}, got $VERSION
 
 	mkdir -p ~/.local/bin &&
 	cp ~/.llama-app/llama ~/.local/bin/llama.tmp &&


### PR DESCRIPTION
On my system, `llama version` now writes the following to stderr:

```
version: 0.1.0-dev (build 10435, commit 9e40df63b)
built with AppleClang 21.0.0.21000101 for Darwin aarch64
```

which differs from the previous format (written to `stdout`):

```
b10217-ddd4ec142
```

Fixes #88 hopefully