### PR TITLE
Apply version format fix to Windows install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -98,13 +98,14 @@ function Main {
         "Installation skipped, SKIP_INSTALL is set"
         return
     }
-    $Version = & "$DIR\llama.exe" version 2>$null
+    $Version = & "$DIR\llama.exe" version 2>&1
 
     if ($LASTEXITCODE) {
         Die "Downloaded llama binary failed to run"
     }
-    if ("$Version" -notlike "$LLAMA_VERSION-*") {
-        Die "Version mismatch: expected $LLAMA_VERSION, got $Version"
+    $BUILD = $LLAMA_VERSION -replace "^b", ""
+    if ("$Version" -notlike "$LLAMA_VERSION-*" -and "$Version" -notlike "*build $BUILD*") {
+        Die "Version mismatch: expected build $BUILD, got $Version"
     }
     if (Test-Path "$INSTALL_DIR\llama.exe") {
         Move-Item "$INSTALL_DIR\llama.exe" "$DIR\llama.exe.old" -Force


### PR DESCRIPTION
This replicates #89 and #90 for Windows. Sorry this is taking so many iterations, I didn't realize that Windows uses a PowerShell install script.

I don't currently have access to a Windows machine, tested the parsing process with a macOS version of PowerShell.