### PR TITLE
Allow avx512fp16 without amx-bf16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,8 @@ jobs:
           - x86_64-linux-cpu-klxrk
           - x86_64-linux-cpu-knxrk
           - x86_64-linux-cpu-krxrk
+          - x86_64-linux-cpu-knxzk
+          - x86_64-linux-cpu-krxzk
           - x86_64-linux-cpu-knxzq
           - x86_64-linux-cpu-krxzq
     uses: ./.github/workflows/build-any-cpu.yml
@@ -187,6 +189,8 @@ jobs:
           - x86_64-windows-cpu-klxrk
           - x86_64-windows-cpu-knxrk
           - x86_64-windows-cpu-krxrk
+          - x86_64-windows-cpu-knxzk
+          - x86_64-windows-cpu-krxzk
           - x86_64-windows-cpu-knxzq
           - x86_64-windows-cpu-krxzq
     uses: ./.github/workflows/build-any-cpu.yml
@@ -263,6 +267,8 @@ jobs:
           - x86_64-freebsd-cpu-klxrk
           - x86_64-freebsd-cpu-knxrk
           - x86_64-freebsd-cpu-krxrk
+          - x86_64-freebsd-cpu-knxzk
+          - x86_64-freebsd-cpu-krxzk
           - x86_64-freebsd-cpu-knxzq
           - x86_64-freebsd-cpu-krxzq
     uses: ./.github/workflows/build-any-cpu.yml
@@ -340,6 +346,8 @@ jobs:
           - x86_64-linux-vulkan-klxrk
           - x86_64-linux-vulkan-knxrk
           - x86_64-linux-vulkan-krxrk
+          - x86_64-linux-vulkan-knxzk
+          - x86_64-linux-vulkan-krxzk
           - x86_64-linux-vulkan-knxzq
           - x86_64-linux-vulkan-krxzq
           - x86_64-linux-vulkan-probe
@@ -418,6 +426,8 @@ jobs:
           - x86_64-windows-vulkan-klxrk
           - x86_64-windows-vulkan-knxrk
           - x86_64-windows-vulkan-krxrk
+          - x86_64-windows-vulkan-knxzk
+          - x86_64-windows-vulkan-krxzk
           - x86_64-windows-vulkan-knxzq
           - x86_64-windows-vulkan-krxzq
           - x86_64-windows-vulkan-probe

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -506,6 +506,30 @@
       "generator": "Ninja"
     },
     {
+      "name": "x86_64-linux-cpu-knxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/linux/cpu/knxzk",
+        "LLAMA_INSTALL_OS": "linux",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16"
+      },
+      "toolchainFile": "toolchains/cross.cmake",
+      "generator": "Ninja"
+    },
+    {
+      "name": "x86_64-linux-cpu-krxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/linux/cpu/krxzk",
+        "LLAMA_INSTALL_OS": "linux",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavxvnniint8 -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16"
+      },
+      "toolchainFile": "toolchains/cross.cmake",
+      "generator": "Ninja"
+    },
+    {
       "name": "x86_64-linux-cpu-knxzq",
       "binaryDir": "build/${presetName}",
       "cacheVariables": {
@@ -1034,6 +1058,30 @@
       "generator": "Ninja"
     },
     {
+      "name": "x86_64-windows-cpu-knxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/windows/cpu/knxzk",
+        "LLAMA_INSTALL_OS": "windows",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16"
+      },
+      "toolchainFile": "toolchains/cross.cmake",
+      "generator": "Ninja"
+    },
+    {
+      "name": "x86_64-windows-cpu-krxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/windows/cpu/krxzk",
+        "LLAMA_INSTALL_OS": "windows",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavxvnniint8 -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16"
+      },
+      "toolchainFile": "toolchains/cross.cmake",
+      "generator": "Ninja"
+    },
+    {
       "name": "x86_64-windows-cpu-knxzq",
       "binaryDir": "build/${presetName}",
       "cacheVariables": {
@@ -1557,6 +1605,30 @@
         "LLAMA_INSTALL_OS": "freebsd",
         "LLAMA_INSTALL_ARCH": "x86_64",
         "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavxvnniint8 -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16"
+      },
+      "toolchainFile": "toolchains/cross.cmake",
+      "generator": "Ninja"
+    },
+    {
+      "name": "x86_64-freebsd-cpu-knxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/freebsd/cpu/knxzk",
+        "LLAMA_INSTALL_OS": "freebsd",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16"
+      },
+      "toolchainFile": "toolchains/cross.cmake",
+      "generator": "Ninja"
+    },
+    {
+      "name": "x86_64-freebsd-cpu-krxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/freebsd/cpu/krxzk",
+        "LLAMA_INSTALL_OS": "freebsd",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavxvnniint8 -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16"
       },
       "toolchainFile": "toolchains/cross.cmake",
       "generator": "Ninja"
@@ -2138,6 +2210,32 @@
         "LLAMA_INSTALL_OS": "linux",
         "LLAMA_INSTALL_ARCH": "x86_64",
         "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavxvnniint8 -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16",
+        "GGML_VULKAN": "ON"
+      },
+      "toolchainFile": "toolchains/vulkan.cmake",
+      "generator": "Ninja"
+    },
+    {
+      "name": "x86_64-linux-vulkan-knxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/linux/vulkan/knxzk",
+        "LLAMA_INSTALL_OS": "linux",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16",
+        "GGML_VULKAN": "ON"
+      },
+      "toolchainFile": "toolchains/vulkan.cmake",
+      "generator": "Ninja"
+    },
+    {
+      "name": "x86_64-linux-vulkan-krxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/linux/vulkan/krxzk",
+        "LLAMA_INSTALL_OS": "linux",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavxvnniint8 -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16",
         "GGML_VULKAN": "ON"
       },
       "toolchainFile": "toolchains/vulkan.cmake",
@@ -2734,6 +2832,32 @@
         "LLAMA_INSTALL_OS": "windows",
         "LLAMA_INSTALL_ARCH": "x86_64",
         "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavxvnniint8 -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16",
+        "GGML_VULKAN": "ON"
+      },
+      "toolchainFile": "toolchains/vulkan.cmake",
+      "generator": "Ninja"
+    },
+    {
+      "name": "x86_64-windows-vulkan-knxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/windows/vulkan/knxzk",
+        "LLAMA_INSTALL_OS": "windows",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16",
+        "GGML_VULKAN": "ON"
+      },
+      "toolchainFile": "toolchains/vulkan.cmake",
+      "generator": "Ninja"
+    },
+    {
+      "name": "x86_64-windows-vulkan-krxzk",
+      "binaryDir": "build/${presetName}",
+      "cacheVariables": {
+        "LLAMA_INSTALL_DIR": "${sourceDir}/output/x86_64/windows/vulkan/krxzk",
+        "LLAMA_INSTALL_OS": "windows",
+        "LLAMA_INSTALL_ARCH": "x86_64",
+        "LLAMA_INSTALL_FLAGS": "-march=x86_64_v4 -mavx -mf16c -mfma -mavx2 -mbmi2 -mavxvnni -mavxvnniint8 -mavx512f -mavx512vl -mavx512bw -mavx512dq -mavx512cd -mavx512vnni -mavx512vbmi -mavx512bf16 -mavx512fp16",
         "GGML_VULKAN": "ON"
       },
       "toolchainFile": "toolchains/vulkan.cmake",
@@ -4045,6 +4169,22 @@
       ]
     },
     {
+      "name": "x86_64-linux-cpu-knxzk",
+      "configurePreset": "x86_64-linux-cpu-knxzk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
+      "name": "x86_64-linux-cpu-krxzk",
+      "configurePreset": "x86_64-linux-cpu-krxzk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
       "name": "x86_64-linux-cpu-knxzq",
       "configurePreset": "x86_64-linux-cpu-knxzq",
       "jobs": 0,
@@ -4397,6 +4537,22 @@
       ]
     },
     {
+      "name": "x86_64-windows-cpu-knxzk",
+      "configurePreset": "x86_64-windows-cpu-knxzk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
+      "name": "x86_64-windows-cpu-krxzk",
+      "configurePreset": "x86_64-windows-cpu-krxzk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
       "name": "x86_64-windows-cpu-knxzq",
       "configurePreset": "x86_64-windows-cpu-knxzq",
       "jobs": 0,
@@ -4743,6 +4899,22 @@
     {
       "name": "x86_64-freebsd-cpu-krxrk",
       "configurePreset": "x86_64-freebsd-cpu-krxrk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
+      "name": "x86_64-freebsd-cpu-knxzk",
+      "configurePreset": "x86_64-freebsd-cpu-knxzk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
+      "name": "x86_64-freebsd-cpu-krxzk",
+      "configurePreset": "x86_64-freebsd-cpu-krxzk",
       "jobs": 0,
       "targets": [
         "llama-install"
@@ -5103,6 +5275,22 @@
     {
       "name": "x86_64-linux-vulkan-krxrk",
       "configurePreset": "x86_64-linux-vulkan-krxrk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
+      "name": "x86_64-linux-vulkan-knxzk",
+      "configurePreset": "x86_64-linux-vulkan-knxzk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
+      "name": "x86_64-linux-vulkan-krxzk",
+      "configurePreset": "x86_64-linux-vulkan-krxzk",
       "jobs": 0,
       "targets": [
         "llama-install"
@@ -5471,6 +5659,22 @@
     {
       "name": "x86_64-windows-vulkan-krxrk",
       "configurePreset": "x86_64-windows-vulkan-krxrk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
+      "name": "x86_64-windows-vulkan-knxzk",
+      "configurePreset": "x86_64-windows-vulkan-knxzk",
+      "jobs": 0,
+      "targets": [
+        "llama-install"
+      ]
+    },
+    {
+      "name": "x86_64-windows-vulkan-krxzk",
+      "configurePreset": "x86_64-windows-vulkan-krxzk",
       "jobs": 0,
       "targets": [
         "llama-install"
@@ -6529,6 +6733,32 @@
       ]
     },
     {
+      "name": "x86_64-linux-cpu-knxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-linux-cpu-knxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-linux-cpu-knxzk"
+        }
+      ]
+    },
+    {
+      "name": "x86_64-linux-cpu-krxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-linux-cpu-krxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-linux-cpu-krxzk"
+        }
+      ]
+    },
+    {
       "name": "x86_64-linux-cpu-knxzq",
       "steps": [
         {
@@ -7101,6 +7331,32 @@
       ]
     },
     {
+      "name": "x86_64-windows-cpu-knxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-windows-cpu-knxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-windows-cpu-knxzk"
+        }
+      ]
+    },
+    {
+      "name": "x86_64-windows-cpu-krxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-windows-cpu-krxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-windows-cpu-krxzk"
+        }
+      ]
+    },
+    {
       "name": "x86_64-windows-cpu-knxzq",
       "steps": [
         {
@@ -7669,6 +7925,32 @@
         {
           "type": "build",
           "name": "x86_64-freebsd-cpu-krxrk"
+        }
+      ]
+    },
+    {
+      "name": "x86_64-freebsd-cpu-knxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-freebsd-cpu-knxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-freebsd-cpu-knxzk"
+        }
+      ]
+    },
+    {
+      "name": "x86_64-freebsd-cpu-krxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-freebsd-cpu-krxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-freebsd-cpu-krxzk"
         }
       ]
     },
@@ -8254,6 +8536,32 @@
         {
           "type": "build",
           "name": "x86_64-linux-vulkan-krxrk"
+        }
+      ]
+    },
+    {
+      "name": "x86_64-linux-vulkan-knxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-linux-vulkan-knxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-linux-vulkan-knxzk"
+        }
+      ]
+    },
+    {
+      "name": "x86_64-linux-vulkan-krxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-linux-vulkan-krxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-linux-vulkan-krxzk"
         }
       ]
     },
@@ -8852,6 +9160,32 @@
         {
           "type": "build",
           "name": "x86_64-windows-vulkan-krxrk"
+        }
+      ]
+    },
+    {
+      "name": "x86_64-windows-vulkan-knxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-windows-vulkan-knxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-windows-vulkan-knxzk"
+        }
+      ]
+    },
+    {
+      "name": "x86_64-windows-vulkan-krxzk",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-windows-vulkan-krxzk"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-windows-vulkan-krxzk"
         }
       ]
     },

--- a/PRESETS.md
+++ b/PRESETS.md
@@ -53,6 +53,8 @@
 | `klxrk` | **x86_64_v4** | `avx` `f16c` `fma` `avx2` `bmi2` `avx512f` `avx512vl` `avx512bw` `avx512dq` `avx512cd` `avx512vnni` `avx512vbmi` `avx512bf16`                                                                       |
 | `knxrk` | **x86_64_v4** | `avx` `f16c` `fma` `avx2` `bmi2` `avxvnni` `avx512f` `avx512vl` `avx512bw` `avx512dq` `avx512cd` `avx512vnni` `avx512vbmi` `avx512bf16`                                                             |
 | `krxrk` | **x86_64_v4** | `avx` `f16c` `fma` `avx2` `bmi2` `avxvnni` `avxvnniint8` `avx512f` `avx512vl` `avx512bw` `avx512dq` `avx512cd` `avx512vnni` `avx512vbmi` `avx512bf16`                                               |
+| `knxzk` | **x86_64_v4** | `avx` `f16c` `fma` `avx2` `bmi2` `avxvnni` `avx512f` `avx512vl` `avx512bw` `avx512dq` `avx512cd` `avx512vnni` `avx512vbmi` `avx512bf16` `avx512fp16`                                                |
+| `krxzk` | **x86_64_v4** | `avx` `f16c` `fma` `avx2` `bmi2` `avxvnni` `avxvnniint8` `avx512f` `avx512vl` `avx512bw` `avx512dq` `avx512cd` `avx512vnni` `avx512vbmi` `avx512bf16` `avx512fp16`                                  |
 | `knxzq` | **x86_64_v4** | `avx` `f16c` `fma` `avx2` `bmi2` `avxvnni` `avx512f` `avx512vl` `avx512bw` `avx512dq` `avx512cd` `avx512vnni` `avx512vbmi` `avx512bf16` `avx512fp16` `amx-tile` `amx-int8` `amx-bf16`               |
 | `krxzq` | **x86_64_v4** | `avx` `f16c` `fma` `avx2` `bmi2` `avxvnni` `avxvnniint8` `avx512f` `avx512vl` `avx512bw` `avx512dq` `avx512cd` `avx512vnni` `avx512vbmi` `avx512bf16` `avx512fp16` `amx-tile` `amx-int8` `amx-bf16` |
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -165,7 +165,9 @@ def generate_x86_64_features():
         ('avx512dq',    'avx512bw'  ),
         ('avx512vnni',  'avx512dq'  ),
         ('avx512bf16',  'avx512vnni'),
-        ('avx512fp16',  'amx-bf16'  ),
+        ('avx512fp16',  'avxvnni'   ),  # instead of ('avx512fp16', 'amx-bf16')
+        ('avx512fp16',  'avx512bf16'),  # see https://github.com/ggml-org/llama-install.sh/issues/92
+        ('avx512fp16',  'avx512vbmi'),  #
         ('amx-tile',    'amx-bf16'  ),
         ('amx-bf16',    'avxvnni'   ),
         ('amx-bf16',    'avx512vbmi'),


### PR DESCRIPTION
Fix #92 by allowing `knxzk` (and `krxzk` with `avxvnniint8`)