### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -12,6 +12,9 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   bench:
     name: ${{ matrix.backend }}:${{ matrix.model }}:${{ matrix.quant }}
@@ -45,4 +48,8 @@ jobs:
       - name: Bench
         env:
           LLAMA_BUCKET: ${{ vars.HF_REPO }}
-        run: python3 scripts/bench-compare.py ${{ matrix.model }}:${{ matrix.quant }} ${{ inputs.base_version }} ${{ inputs.current_version }}
+          MODEL: ${{ matrix.model }}
+          QUANT: ${{ matrix.quant }}
+          BASE_VERSION: ${{ inputs.base_version }}
+          CURRENT_VERSION: ${{ inputs.current_version }}
+        run: python3 scripts/bench-compare.py "$MODEL:$QUANT" "$BASE_VERSION" "$CURRENT_VERSION"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,6 +10,9 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   bench:
     name: ${{ matrix.backend }}:${{ matrix.model }}:${{ matrix.quant }}

--- a/.github/workflows/build-any-cpu.yml
+++ b/.github/workflows/build-any-cpu.yml
@@ -20,6 +20,9 @@ on:
   workflow_dispatch:
     inputs: *common_inputs
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -39,12 +42,15 @@ jobs:
           BORINGSSL_REPO: ${{ inputs.boringssl_repo }}
           BORINGSSL_VERSION: ${{ inputs.boringssl_version }}
           HF_TOKEN: ${{ secrets.HF_TOKEN_READ }}
-        run: cmake --workflow --preset ${{ inputs.filter }}
+          FILTER: ${{ inputs.filter }}
+        run: cmake --workflow --preset "$FILTER"
 
       - name: Deploy
         if: ${{ inputs.deploy && vars.HF_REPO != '' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ vars.HF_REPO }}
+          VERSION: ${{ inputs.llamacpp_version || 'test' }}
         run: |
           pip install -U "hf[hf_xet]"
-          python scripts/upload.py ${{ vars.HF_REPO }}/${{ inputs.llamacpp_version || 'test' }}
+          python scripts/upload.py "$HF_REPO/$VERSION"

--- a/.github/workflows/build-any-cuda.yml
+++ b/.github/workflows/build-any-cuda.yml
@@ -23,6 +23,9 @@ on:
   workflow_dispatch:
     inputs: *common_inputs
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ contains(inputs.filter, '-windows-') && 'windows-2022' || (startsWith(inputs.filter, 'aarch64-') && 'ubuntu-22.04-arm' || 'ubuntu-22.04') }}
@@ -47,7 +50,9 @@ jobs:
 
       - name: Select CUDA version
         shell: bash
-        run: echo "CUDA_VERSION=${CUDA_VERSION_${{ inputs.cuda_code }}}" >> "$GITHUB_ENV"
+        env:
+          CUDA_CODE: ${{ inputs.cuda_code }}
+        run: echo "CUDA_VERSION=${CUDA_VERSION_$CUDA_CODE}" >> "$GITHUB_ENV"
 
       - name: Install cuda
         run: python scripts/install-cuda.py
@@ -59,12 +64,15 @@ jobs:
           BORINGSSL_REPO: ${{ inputs.boringssl_repo }}
           BORINGSSL_VERSION: ${{ inputs.boringssl_version }}
           HF_TOKEN: ${{ secrets.HF_TOKEN_READ }}
-        run: cmake --workflow --preset ${{ inputs.filter }}
+          FILTER: ${{ inputs.filter }}
+        run: cmake --workflow --preset "$FILTER"
 
       - name: Deploy
         if: ${{ inputs.deploy && vars.HF_REPO != '' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ vars.HF_REPO }}
+          VERSION: ${{ inputs.llamacpp_version || 'test' }}
         run: |
           pip install -U "hf[hf_xet]"
-          python scripts/upload.py ${{ vars.HF_REPO }}/${{ inputs.llamacpp_version || 'test' }}
+          python scripts/upload.py "$HF_REPO/$VERSION"

--- a/.github/workflows/build-any-metal.yml
+++ b/.github/workflows/build-any-metal.yml
@@ -20,6 +20,9 @@ on:
   workflow_dispatch:
     inputs: *common_inputs
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-26
@@ -33,12 +36,15 @@ jobs:
           BORINGSSL_REPO: ${{ inputs.boringssl_repo }}
           BORINGSSL_VERSION: ${{ inputs.boringssl_version }}
           HF_TOKEN: ${{ secrets.HF_TOKEN_READ }}
-        run: cmake --workflow --preset ${{ inputs.filter }}
+          FILTER: ${{ inputs.filter }}
+        run: cmake --workflow --preset "$FILTER"
 
       - name: Deploy
         if: ${{ inputs.deploy && vars.HF_REPO != '' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ vars.HF_REPO }}
+          VERSION: ${{ inputs.llamacpp_version || 'test' }}
         run: |
           pip install -U "hf[hf_xet]"
-          python scripts/upload.py ${{ vars.HF_REPO }}/${{ inputs.llamacpp_version || 'test' }}
+          python scripts/upload.py "$HF_REPO/$VERSION"

--- a/.github/workflows/build-any-rocm.yml
+++ b/.github/workflows/build-any-rocm.yml
@@ -20,6 +20,9 @@ on:
   workflow_dispatch:
     inputs: *common_inputs
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -30,8 +33,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install deps
+        env:
+          FILTER: ${{ inputs.filter }}
         run: |
-          GFX="${{ inputs.filter }}"
+          GFX="$FILTER"
           GFX="${GFX##*-}"
           case "$GFX" in
           (probe) ROCM="rocm[devel,libraries]" ;;
@@ -49,12 +54,15 @@ jobs:
           BORINGSSL_REPO: ${{ inputs.boringssl_repo }}
           BORINGSSL_VERSION: ${{ inputs.boringssl_version }}
           HF_TOKEN: ${{ secrets.HF_TOKEN_READ }}
-        run: cmake --workflow --preset ${{ inputs.filter }}
+          FILTER: ${{ inputs.filter }}
+        run: cmake --workflow --preset "$FILTER"
 
       - name: Deploy
         if: ${{ inputs.deploy && vars.HF_REPO != '' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ vars.HF_REPO }}
+          VERSION: ${{ inputs.llamacpp_version || 'test' }}
         run: |
           pip install -U "hf[hf_xet]"
-          python scripts/upload.py ${{ vars.HF_REPO }}/${{ inputs.llamacpp_version || 'test' }}
+          python scripts/upload.py "$HF_REPO/$VERSION"

--- a/.github/workflows/build-any-vulkan.yml
+++ b/.github/workflows/build-any-vulkan.yml
@@ -20,6 +20,9 @@ on:
   workflow_dispatch:
     inputs: *common_inputs
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -46,12 +49,15 @@ jobs:
           BORINGSSL_REPO: ${{ inputs.boringssl_repo }}
           BORINGSSL_VERSION: ${{ inputs.boringssl_version }}
           HF_TOKEN: ${{ secrets.HF_TOKEN_READ }}
-        run: cmake --workflow --preset ${{ inputs.filter }}
+          FILTER: ${{ inputs.filter }}
+        run: cmake --workflow --preset "$FILTER"
 
       - name: Deploy
         if: ${{ inputs.deploy && vars.HF_REPO != '' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ vars.HF_REPO }}
+          VERSION: ${{ inputs.llamacpp_version || 'test' }}
         run: |
           pip install -U "hf[hf_xet]"
-          python scripts/upload.py ${{ vars.HF_REPO }}/${{ inputs.llamacpp_version || 'test' }}
+          python scripts/upload.py "$HF_REPO/$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
         type: boolean
   schedule:
     - cron: 0 0 * * 6
+
+permissions:
+  contents: read
+
 jobs:
   init:
     runs-on: ubuntu-latest
@@ -28,15 +32,18 @@ jobs:
         id: tags
         env:
           GH_TOKEN: ${{ github.token }}
+          LLAMACPP_INPUT: ${{ inputs.llamacpp_version }}
+          EVENT_NAME: ${{ github.event_name }}
+          WRITE_LATEST_INPUT: ${{ inputs.write_latest }}
         run: |
-          if [ "${{ inputs.llamacpp_version }}" ]
-          then LLAMACPP_VERSION="${{ inputs.llamacpp_version }}"
+          if [ "$LLAMACPP_INPUT" ]
+          then LLAMACPP_VERSION="$LLAMACPP_INPUT"
           else LLAMACPP_VERSION=$(gh api "repos/ggml-org/llama.cpp/releases?per_page=30" --jq '[.[] | select(.tag_name|test("^b[0-9]+$"))][0].tag_name')
           fi
           BORINGSSL_VERSION=$(git ls-remote --tags https://boringssl.googlesource.com/boringssl | sed -nE 's,.*/tags/(0\.[0-9]+\.0)$,\1,p' | sort | tail -n 1)
-          if [ "${{ github.event_name }}" = "schedule" ]
+          if [ "$EVENT_NAME" = "schedule" ]
           then WRITE_LATEST="true"
-          else WRITE_LATEST="${{ inputs.write_latest }}"
+          else WRITE_LATEST="$WRITE_LATEST_INPUT"
           fi
           cat <<EOF >> "$GITHUB_OUTPUT"
           llamacpp_version=$LLAMACPP_VERSION
@@ -643,10 +650,12 @@ jobs:
         if: ${{ vars.HF_REPO != '' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ vars.HF_REPO }}
+          VERSION: ${{ needs.init.outputs.llamacpp_version }}
         run: |
           pip install -U "hf[hf_xet]"
           python scripts/fetch-artefacts.py
-          python scripts/upload.py ${{ vars.HF_REPO }}/${{ needs.init.outputs.llamacpp_version }}
+          python scripts/upload.py "$HF_REPO/$VERSION"
           rm -rf output
 
   test:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -15,6 +15,9 @@ on:
   workflow_call:
     inputs: *inputs
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (${{ matrix.platform }})
@@ -63,8 +66,10 @@ jobs:
       - name: Write latest file
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ vars.HF_REPO }}
+          VERSION: ${{ inputs.llamacpp_version }}
         run: |
           pip install -U "hf[hf_xet]"
           mkdir output
-          printf "${{ inputs.llamacpp_version }}" > output/latest
-          python scripts/upload.py ${{ vars.HF_REPO }}
+          printf '%s' "$VERSION" > output/latest
+          python scripts/upload.py "$HF_REPO"


### PR DESCRIPTION
- Set explicit `permissions: contents: read` on all workflows
  (release.yml gets `contents: write` only where needed)

- Pass user-controlled inputs via environment variables instead of direct `${{ }}` interpolation in run blocks, mitigating script injection